### PR TITLE
codecov support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,3 +31,6 @@ jobs:
       with:
         file: ./coverage.xml
         flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: true
+          

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # METEOR
 Map Enhancement Tools for Ephemeral Occupancy Refinement
-(set of tools for crystallographic electron density maps containing low ligand/species populations)
+----------
+
+# Your Project Name
+
+[![Pytest](https://github.com/alisiafadini/meteor/actions/workflows/tests.yml/badge.svg)](https://github.com/your_username/your_repo/actions/workflows/tests.yml)
+[![Mypy](https://github.com/alisiafadini/meteor/actions/workflows/mypy.yml/badge.svg)](https://github.com/your_username/your_repo/actions/workflows/mypy.yml)
+[![Ruff](https://github.com/alisiafadini/meteor/actions/workflows/lint.yml/badge.svg)](https://github.com/your_username/your_repo/actions/workflows/lint.yml)
+[![codecov](https://codecov.io/gh/your_username/your_repo/branch/main/graph/badge.svg)](https://codecov.io/gh/your_username/your_repo)
+
+Set of tools for crystallographic electron density maps containing low ligand/species populations.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 Map Enhancement Tools for Ephemeral Occupancy Refinement
 ----------
 
-# Your Project Name
-
 [![Pytest](https://github.com/alisiafadini/meteor/actions/workflows/tests.yml/badge.svg)](https://github.com/your_username/your_repo/actions/workflows/tests.yml)
 [![Mypy](https://github.com/alisiafadini/meteor/actions/workflows/mypy.yml/badge.svg)](https://github.com/your_username/your_repo/actions/workflows/mypy.yml)
 [![Ruff](https://github.com/alisiafadini/meteor/actions/workflows/lint.yml/badge.svg)](https://github.com/your_username/your_repo/actions/workflows/lint.yml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "scikit-image",
     "reciprocalspaceship",
     "pytest",
+    "pytest-cov",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,6 @@ exclude = [
     "__pycache__/",
     "*.pyc",
 ]
+
+[tool.pytest.ini_options]
+addopts = "--cov=meteor --cov-report=xml"


### PR DESCRIPTION
This PR adds codecov support, so that we can automatically monitor how much of the code base is covered by tests. As a bonus, I've added badges for the different checks we're running.

@alisiafadini since you own this repo, for this to work, you have to make an account at [codecov](https://codecov.io/) and give them access to this repo. Then it should work!