### PR TITLE
generic scalar parameter optimization

### DIFF
--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -216,7 +216,6 @@ def scale_datasets(
         )
 
     for column in columns_to_scale:
-        print(f"Scaling: {column}")
         scaled_dataset[column] *= scale_factors
 
     return scaled_dataset

--- a/meteor/validate.py
+++ b/meteor/validate.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, Sequence
 
 import numpy as np
 from scipy.optimize import minimize_scalar
@@ -96,7 +96,7 @@ class ScalarMaximizer:
             self.argument_optimum = argument_test_value
             self.objective_maximum = objective_value
 
-    def optimize_over_explicit_values(self, *, arguments_to_scan: list[float] | np.ndarray):
+    def optimize_over_explicit_values(self, *, arguments_to_scan: Sequence[float] | np.ndarray):
         """
         Scans through a list or array of argument values to find the optimum.
 

--- a/meteor/validate.py
+++ b/meteor/validate.py
@@ -1,4 +1,7 @@
+from typing import Callable
+
 import numpy as np
+from scipy.optimize import minimize_scalar
 from scipy.stats import differential_entropy
 
 
@@ -48,3 +51,90 @@ def negentropy(samples: np.ndarray, tolerance: float = 0.1) -> float:
         )
 
     return neg_e
+
+
+class ScalarMaximizer:
+    """
+    Maximize a function using one of two strategies, or a combination of both:
+
+      1. simply loop over an explicit list of argument values and pick the max
+      2. use the Golden ratio method to try and be a bit faster
+
+    The objective function to maximize must be a scalar mapping, taking a single float as an
+    argument and returning a single float. In the context of METEOR, this is useful to e.g.
+    maximize over simple parameter choices, such as TV regularization strength or k-weight values.
+
+    Attributes:
+    ----------
+    objective : Callable[[float], float]
+        The objective function to maximize.
+    argument_optimum : float
+        The argument (input) that gives the highest objective value found so far.
+    objective_maximum : float
+        The maximum value of the objective function found so far.
+    values_evaluated : set[float]
+        A set of argument values that have been evaluated during optimization.
+    """
+
+    def __init__(self, *, objective: Callable[[float], float]):
+        """
+        Initializes the Maximizer with the given objective function.
+
+        Parameters:
+        ----------
+        objective : Callable[[float], float]
+            The objective function to be maximized. It should map a single float to a float.
+        """
+        self.objective = objective
+        self.argument_optimum: float = np.nan
+        self.objective_maximum: float = -np.inf
+        self.values_evaluated: set[float] = set()
+
+    def _update_optima(self, argument_test_value):
+        objective_value = self.objective(argument_test_value)
+        if objective_value > self.objective_maximum:
+            self.argument_optimum = argument_test_value
+            self.objective_maximum = objective_value
+
+    def optimize_over_explicit_values(self, *, arguments_to_scan: list[float] | np.ndarray):
+        """
+        Scans through a list or array of argument values to find the optimum.
+
+        Parameters:
+        ----------
+        arguments_to_scan : list[float] | np.ndarray
+            A list or array of argument values to evaluate.
+        """
+        for argument_test_value in arguments_to_scan:
+            self._update_optima(argument_test_value)
+            self.values_evaluated.add(argument_test_value)
+
+    def optimize_with_golden_algorithm(self, *, bracket: tuple[float, float]):
+        """
+        Uses the golden-section search algorithm to maximize the objective function within a given
+        bracket.
+
+        Parameters:
+        ----------
+        bracket : tuple[float, float]
+            A tuple containing the lower and upper bounds of the bracket within which to search
+            for the optimum.
+
+        Raises:
+        -------
+        RuntimeError
+            If the optimization using the golden algorithm fails.
+        """
+
+        def _objective_with_value_tracking(argument_test_value):
+            """adds the evaluated value to self.values_evaluated"""
+            self.values_evaluated.add(argument_test_value)
+            return -self.objective(argument_test_value)  # negative: we want max
+
+        optimizer_result = minimize_scalar(
+            _objective_with_value_tracking, bracket=bracket, method="golden"
+        )
+        if not optimizer_result.success:
+            raise RuntimeError("Golden minimization failed")
+
+        self._update_optima(optimizer_result.x)

--- a/meteor/validate.py
+++ b/meteor/validate.py
@@ -109,7 +109,9 @@ class ScalarMaximizer:
             self._update_optima(argument_test_value)
             self.values_evaluated.add(argument_test_value)
 
-    def optimize_with_golden_algorithm(self, *, bracket: tuple[float, float]):
+    def optimize_with_golden_algorithm(
+        self, *, bracket: tuple[float, float], tolerance: float = 0.001
+    ):
         """
         Uses the golden-section search algorithm to maximize the objective function within a given
         bracket.
@@ -132,7 +134,7 @@ class ScalarMaximizer:
             return -self.objective(argument_test_value)  # negative: we want max
 
         optimizer_result = minimize_scalar(
-            _objective_with_value_tracking, bracket=bracket, method="golden"
+            _objective_with_value_tracking, bracket=bracket, method="golden", tol=tolerance
         )
         if not optimizer_result.success:
             raise RuntimeError("Golden minimization failed")

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -65,7 +65,6 @@ def test_compute_scale_factors_anisotropic(miller_dataseries: rs.DataSeries) -> 
     scale_factors = scale.compute_scale_factors(
         reference_values=miller_dataseries, values_to_scale=flat_miller_dataseries
     )
-    print("***", scale_factors)
     np.testing.assert_array_almost_equal(scale_factors, miller_dataseries.values)
 
 

--- a/test/unit/test_validate.py
+++ b/test/unit/test_validate.py
@@ -1,6 +1,12 @@
 import numpy as np
+from numpy.testing import assert_almost_equal
 
 from meteor import validate
+
+
+def parabolic_objective(x: float) -> float:
+    # has a maximum of y = 0 at x = 1
+    return -(x**2) + 2 * x - 1
 
 
 def test_negentropy_gaussian() -> None:
@@ -24,3 +30,20 @@ def test_negentropy_uniform() -> None:
 def test_negentropy_zero() -> None:
     negentropy = validate.negentropy(np.zeros(100))
     assert negentropy == -np.inf
+
+
+def test_negentropy_maximizer_explicit() -> None:
+    maximizer = validate.ScalarMaximizer(objective=parabolic_objective)
+    test_values = np.linspace(-5, 5, 11)
+    maximizer.optimize_over_explicit_values(arguments_to_scan=test_values)
+    assert_almost_equal(maximizer.argument_optimum, 1.0)
+    assert_almost_equal(maximizer.objective_maximum, 0.0)
+    assert set(test_values) == maximizer.values_evaluated
+
+
+def test_negentropy_maximizer_golden() -> None:
+    maximizer = validate.ScalarMaximizer(objective=parabolic_objective)
+    maximizer.optimize_with_golden_algorithm(bracket=(-5, 5))
+    assert_almost_equal(maximizer.argument_optimum, 1.0)
+    assert_almost_equal(maximizer.objective_maximum, 0.0)
+    assert len(maximizer.values_evaluated) > 0

--- a/test/unit/test_validate.py
+++ b/test/unit/test_validate.py
@@ -44,6 +44,6 @@ def test_negentropy_maximizer_explicit() -> None:
 def test_negentropy_maximizer_golden() -> None:
     maximizer = validate.ScalarMaximizer(objective=parabolic_objective)
     maximizer.optimize_with_golden_algorithm(bracket=(-5, 5))
-    assert_almost_equal(maximizer.argument_optimum, 1.0)
-    assert_almost_equal(maximizer.objective_maximum, 0.0)
+    assert_almost_equal(maximizer.argument_optimum, 1.0, decimal=2)
+    assert_almost_equal(maximizer.objective_maximum, 0.0, decimal=2)
     assert len(maximizer.values_evaluated) > 0


### PR DESCRIPTION
This PR provides a general way to optimize a scalar parameter, flexibly swapping between either:
1. a specific list of values to evaluate, or
2. the Golden algorithm

Explicit applications:
* optimizing lambda in TV denoising and
* optimizing the `k` parameter in k-weighting

specifically by maximizing the negentropy, though that is not required by the code.

While it should really go in another PR, this PR also cleans up a few stray prints that were left over from the recently merged scaling PR (#14).