### PR TITLE
polar / Cartesian interconverters

### DIFF
--- a/meteor/utils.py
+++ b/meteor/utils.py
@@ -104,8 +104,10 @@ def rs_dataseies_to_complex_array(amplitudes: rs.DataSeries, phases: rs.DataSeri
     try:
         assert_index_equal(amplitudes.index, phases.index)
     except AssertionError as exptn:
-        ShapeMismatchError(
+        raise ShapeMismatchError(
             f"indices for `amplitudes` and `phases` don't match: {amplitudes.index} {phases.index}",
+            " To safely cast to a single complex array, pass DataSeries with a common set of",
+            " indices. One possible way: Series.align(other, join='inner', axis=0).",
             exptn,
         )
     complex_structure_factors = amplitudes.to_numpy() * np.exp(1j * np.deg2rad(phases.to_numpy()))

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import reciprocalspaceship as rs
+from pandas import testing as pdt
 
 from meteor import utils
 
@@ -76,6 +77,63 @@ def test_canonicalize_amplitudes(
         np.array(np.abs(random_difference_map[diffmap_labels.amplitude])),
         np.array(canonicalized[diffmap_labels.amplitude]),
     )
+
+
+def test_rs_dataseies_to_complex_array() -> None:
+    index = pd.Index(np.arange(4))
+    amp = rs.DataSeries(np.ones(4), index=index)
+    phase = rs.DataSeries(np.arange(4) * 90.0, index=index)
+
+    carray = utils.rs_dataseies_to_complex_array(amp, phase)
+    expected = np.array([1.0, 0.0, -1.0, 0.0]) + 1j * np.array([0.0, 1.0, 0.0, -1.0])
+
+    np.testing.assert_almost_equal(carray, expected)
+
+
+def test_rs_dataseies_to_complex_array_index_mismatch() -> None:
+    amp = rs.DataSeries(np.ones(4), index=[0, 1, 2, 3])
+    phase = rs.DataSeries(np.arange(4) * 90.0, index=[1, 2, 3, 4])
+    with pytest.raises(utils.ShapeMismatchError):
+        utils.rs_dataseies_to_complex_array(amp, phase)
+
+
+def test_complex_array_to_rs_dataseries() -> None:
+    carray = np.array([1.0, 0.0, -1.0, 0.0]) + 1j * np.array([0.0, 1.0, 0.0, -1.0])
+    index = pd.Index(np.arange(4))
+
+    expected_amp = rs.DataSeries(np.ones(4), index=index).astype(rs.StructureFactorAmplitudeDtype())
+    expected_phase = rs.DataSeries([0.0, 90.0, 180.0, -90.0], index=index).astype(rs.PhaseDtype())
+
+    amp, phase = utils.complex_array_to_rs_dataseries(carray, index)
+    pdt.assert_series_equal(amp, expected_amp)
+    pdt.assert_series_equal(phase, expected_phase)
+
+
+def test_complex_array_to_rs_dataseries_index_mismatch() -> None:
+    carray = np.array([1.0]) + 1j * np.array([1.0])
+    index = pd.Index(np.arange(2))
+    with pytest.raises(utils.ShapeMismatchError):
+        utils.complex_array_to_rs_dataseries(carray, index)
+
+
+def test_complex_array_dataseries_roundtrip() -> None:
+    n = 5
+    carray = np.random.randn(n) + 1j * np.random.randn(n)
+    indices = pd.Index(np.arange(n))
+
+    ds_amplitudes, ds_phases = utils.complex_array_to_rs_dataseries(carray, indices)
+
+    assert isinstance(ds_amplitudes, rs.DataSeries)
+    assert isinstance(ds_phases, rs.DataSeries)
+
+    assert ds_amplitudes.dtype == rs.StructureFactorAmplitudeDtype()
+    assert ds_phases.dtype == rs.PhaseDtype()
+
+    pdt.assert_index_equal(ds_amplitudes.index, indices)
+    pdt.assert_index_equal(ds_phases.index, indices)
+
+    carray2 = utils.rs_dataseies_to_complex_array(ds_amplitudes, ds_phases)
+    np.testing.assert_almost_equal(carray, carray2, decimal=5)
 
 
 def test_compute_map_from_coefficients(


### PR DESCRIPTION
PR provides support for exchanging between polar (amp/phase) and Cartesian (x + i * y) representations of structure factor amplitudes.

Merge this PR before #14 and #15 and re-use this code in those PRs.