### PR TITLE
swap scaler from DataSet to Map

### DIFF
--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -184,17 +184,18 @@ def scale_maps(
     ----------
     [1] SCALEIT https://www.ccp4.ac.uk/html/scaleit.html
     """
-    if (
-        weight_using_uncertainties
-        and reference_map.has_uncertainties
-        and map_to_scale.has_uncertainties
-    ):
-        scale_factors = compute_scale_factors(
-            reference_values=reference_map.amplitudes,
-            values_to_scale=map_to_scale.amplitudes,
-            reference_uncertainties=reference_map.uncertainties,
-            to_scale_uncertainties=map_to_scale.uncertainties,
-        )
+    if weight_using_uncertainties:
+        if reference_map.has_uncertainties and map_to_scale.has_uncertainties:
+            scale_factors = compute_scale_factors(
+                reference_values=reference_map.amplitudes,
+                values_to_scale=map_to_scale.amplitudes,
+                reference_uncertainties=reference_map.uncertainties,
+                to_scale_uncertainties=map_to_scale.uncertainties,
+            )
+        else:
+            msg = "requested `weight_using_uncertainties=True`, but either `reference_map`, "
+            msg += "`map_to_scale` or both are missing an uncertainties column"
+            raise ValueError(msg)
 
     else:
         scale_factors = compute_scale_factors(

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -9,7 +9,6 @@ import scipy.optimize as opt
 
 from .rsmap import Map
 
-
 ScaleParameters = Tuple[float, float, float, float, float, float, float]
 """ 7x float tuple to hold anisotropic scaling parameters """
 
@@ -185,8 +184,11 @@ def scale_maps(
     ----------
     [1] SCALEIT https://www.ccp4.ac.uk/html/scaleit.html
     """
-
-    if weight_using_uncertainties and reference_map.has_uncertainties and map_to_scale.has_uncertainties:
+    if (
+        weight_using_uncertainties
+        and reference_map.has_uncertainties
+        and map_to_scale.has_uncertainties
+    ):
         scale_factors = compute_scale_factors(
             reference_values=reference_map.amplitudes,
             values_to_scale=map_to_scale.amplitudes,
@@ -196,8 +198,7 @@ def scale_maps(
 
     else:
         scale_factors = compute_scale_factors(
-            reference_values=reference_map.amplitudes,
-            values_to_scale=map_to_scale.amplitudes
+            reference_values=reference_map.amplitudes, values_to_scale=map_to_scale.amplitudes
         )
 
     scaled_map: Map = map_to_scale.copy()

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -77,56 +77,28 @@ def test_compute_scale_factors_anisotropic(miller_dataseries: rs.DataSeries) -> 
     np.testing.assert_array_almost_equal(scale_factors, miller_dataseries.values)
 
 
-def test_scale_datasets(
-    random_difference_map: Map,
-    test_map_columns: MapColumns,
-) -> None:
+@pytest.mark.parametrize("use_uncertainties", [False, True])
+def test_scale_maps(random_difference_map: Map, use_uncertainties: bool) -> None:
     multiple = 2.0
-    doubled_difference_map = random_difference_map.copy()
-    doubled_difference_map[test_map_columns.amplitude] /= multiple
+    doubled_difference_map: Map = random_difference_map.copy()
+    doubled_difference_map.amplitudes /= multiple
 
-    scaled = scale.scale_datasets(
-        reference_dataset=random_difference_map,
-        dataset_to_scale=doubled_difference_map,
-        column_to_compare=test_map_columns.amplitude,
-        weight_using_uncertainties=False,
+    scaled = scale.scale_maps(
+        reference_map=random_difference_map,
+        map_to_scale=doubled_difference_map,
+        weight_using_uncertainties=use_uncertainties,
     )
     np.testing.assert_array_almost_equal(
-        scaled[test_map_columns.amplitude],
-        random_difference_map[test_map_columns.amplitude],
+        scaled.amplitudes,
+        random_difference_map.amplitudes,
     )
     np.testing.assert_array_almost_equal(
-        scaled[test_map_columns.phase],
-        random_difference_map[test_map_columns.phase],
+        scaled.phases,
+        random_difference_map.phases,
+    )
+    np.testing.assert_array_almost_equal(
+        scaled.uncertainties / multiple,
+        random_difference_map.uncertainties,
     )
 
 
-def test_scale_datasets_with_errors(
-    random_difference_map: Map,
-    test_map_columns: MapColumns,
-) -> None:
-    multiple = 2.0
-    doubled_difference_map = random_difference_map.copy()
-    doubled_difference_map[test_map_columns.amplitude] /= multiple
-
-    scaled = scale.scale_datasets(
-        reference_dataset=random_difference_map,
-        dataset_to_scale=doubled_difference_map,
-        column_to_compare=test_map_columns.amplitude,
-        uncertainty_column=str(test_map_columns.uncertainty),
-        weight_using_uncertainties=True,
-    )
-    np.testing.assert_array_almost_equal(
-        scaled[test_map_columns.amplitude],
-        random_difference_map[test_map_columns.amplitude],
-    )
-    np.testing.assert_array_almost_equal(
-        scaled[test_map_columns.phase],
-        random_difference_map[test_map_columns.phase],
-    )
-
-    # also make sure we scale the uncertainties
-    np.testing.assert_array_almost_equal(
-        scaled[test_map_columns.uncertainty] / multiple,
-        random_difference_map[test_map_columns.uncertainty],
-    )

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -6,7 +6,6 @@ import reciprocalspaceship as rs
 from meteor import scale
 from meteor.rsmap import Map
 from meteor.scale import _compute_anisotropic_scale_factors
-from meteor.testing import MapColumns
 
 
 @pytest.fixture
@@ -100,5 +99,3 @@ def test_scale_maps(random_difference_map: Map, use_uncertainties: bool) -> None
         scaled.uncertainties / multiple,
         random_difference_map.uncertainties,
     )
-
-

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -99,3 +99,23 @@ def test_scale_maps(random_difference_map: Map, use_uncertainties: bool) -> None
         scaled.uncertainties / multiple,
         random_difference_map.uncertainties,
     )
+
+
+def test_scale_maps_no_uncertainties_error(random_difference_map: Map) -> None:
+    no_uncertainties: Map = random_difference_map.copy()
+    del no_uncertainties[no_uncertainties._uncertainty_column]
+
+    with pytest.raises(ValueError, match="requested `weight_using_uncertainties=True`"):
+        _ = scale.scale_maps(
+            reference_map=random_difference_map,
+            map_to_scale=no_uncertainties,
+            weight_using_uncertainties=True,
+        )
+
+    # swap order of maps to test both arguments
+    with pytest.raises(ValueError, match="requested `weight_using_uncertainties=True`"):
+        _ = scale.scale_maps(
+            reference_map=no_uncertainties,
+            map_to_scale=random_difference_map,
+            weight_using_uncertainties=True,
+        )


### PR DESCRIPTION
Introduce a simple function that scales two `Map`s.

We had a kinda nasty version that attempted to serve this need, consuming `rs.DataSet`s instead. This PR removes this.