### PR TITLE
TV weights equal or less than zero

### DIFF
--- a/meteor/rsmap.py
+++ b/meteor/rsmap.py
@@ -12,6 +12,7 @@ from .settings import GEMMI_HIGH_RESOLUTION_BUFFER
 from .utils import (
     canonicalize_amplitudes,
     complex_array_to_rs_dataseries,
+    numpy_array_to_map,
 )
 
 
@@ -306,6 +307,23 @@ class Map(rs.DataSet):
             amplitude_column=amplitude_column,
             phase_column=phase_column,
             uncertainty_column=uncertainty_column,
+        )
+
+    @classmethod
+    def from_numpy_map(
+        cls, map_grid: np.ndarray, *, spacegroup: Any, cell: Any, high_resolution_limit: float
+    ) -> Map:
+        if len(map_grid.shape) != 3:  # noqa: PLR2004 - three is a magic number of dimensions
+            msg = "`map_grid` should be a 3D array representing a realspace map"
+            raise ValueError(msg)
+        ccp4 = numpy_array_to_map(
+            map_grid,
+            spacegroup=spacegroup,
+            cell=cell,
+        )
+        return cls.from_ccp4_map(
+            ccp4_map=ccp4,
+            high_resolution_limit=high_resolution_limit,
         )
 
     def to_ccp4_map(self, *, map_sampling: int) -> gemmi.Ccp4Map:

--- a/meteor/rsmap.py
+++ b/meteor/rsmap.py
@@ -250,11 +250,14 @@ class Map(rs.DataSet):
         else:
             # otherwise, create a new column
             self._uncertainty_column = column_name
-            position = len(self.columns)
-            if position != 2:  # noqa: PLR2004, should be 2: just amplitudes & phases
+            number_of_columns = len(self.columns)
+            number_of_columns_with_just_amplitudes_and_phases = 2
+            if number_of_columns != number_of_columns_with_just_amplitudes_and_phases:
                 msg = "Misconfigured columns"
                 raise RuntimeError(msg)
-            super().insert(position, self._uncertainty_column, values, allow_duplicates=False)
+            super().insert(
+                number_of_columns, self._uncertainty_column, values, allow_duplicates=False
+            )
 
     @property
     def complex_amplitudes(self) -> np.ndarray:
@@ -310,10 +313,35 @@ class Map(rs.DataSet):
         )
 
     @classmethod
-    def from_numpy_map(
+    def from_3d_numpy_map(
         cls, map_grid: np.ndarray, *, spacegroup: Any, cell: Any, high_resolution_limit: float
     ) -> Map:
-        if len(map_grid.shape) != 3:  # noqa: PLR2004 - three is a magic number of dimensions
+        """
+        Create a `Map` from a 3d grid of voxel values stored in a numpy array.
+
+        Parameters
+        ----------
+        map_grid: np.ndarray
+            The array, laid out in Gemmi format
+        spacegroup: Any
+            Specifies which spacegroup, can be an int, gemmi.SpaceGroup, ...
+        cell
+            Specifies cell, can be a tuple, gemmi.Cell, ...
+        high_resolution_limit: float
+            The resolution of the map, irregardless of the sampling; we need this to infer the map
+            sampling
+
+        Returns
+        -------
+        map: Map
+            The map coefficients
+
+        See Also
+        --------
+        For information about Gemmi data layout: https://gemmi.readthedocs.io/en/latest/grid.html
+        """
+        number_of_dimensions_in_universe = 3
+        if len(map_grid.shape) != number_of_dimensions_in_universe:
             msg = "`map_grid` should be a 3D array representing a realspace map"
             raise ValueError(msg)
         ccp4 = numpy_array_to_map(

--- a/meteor/tv.py
+++ b/meteor/tv.py
@@ -130,7 +130,7 @@ def tv_denoise_difference_map(
         map_as_array=realspace_map_array,
         weight=maximizer.argument_optimum,
     )
-    final_map = Map.from_numpy_map(
+    final_map = Map.from_3d_numpy_map(
         final_realspace_map_as_array,
         spacegroup=difference_map.spacegroup,
         cell=difference_map.cell,

--- a/meteor/tv.py
+++ b/meteor/tv.py
@@ -137,6 +137,10 @@ def tv_denoise_difference_map(
         high_resolution_limit=difference_map.resolution_limits[1],
     )
 
+    # propogate uncertainties
+    if difference_map.has_uncertainties:
+        final_map.set_uncertainties(difference_map.uncertainties)
+
     # sometimes `from_ccp4_map` adds reflections -- systematic absences or
     # reflections just beyond the resolution limt; remove those
     extra_indices = final_map.index.difference(difference_map.index)

--- a/meteor/tv.py
+++ b/meteor/tv.py
@@ -13,9 +13,6 @@ from .settings import (
     TV_MAX_NUM_ITER,
     TV_STOP_TOLERANCE,
 )
-from .utils import (
-    numpy_array_to_map,
-)
 from .validate import ScalarMaximizer, negentropy
 
 
@@ -29,6 +26,8 @@ class TvDenoiseResult:
 
 def _tv_denoise_array(*, map_as_array: np.ndarray, weight: float) -> np.ndarray:
     """Closure convienence function to generate more readable code."""
+    if weight <= 0.0:
+        return map_as_array
     return denoise_tv_chambolle(
         map_as_array,
         weight=weight,
@@ -131,14 +130,10 @@ def tv_denoise_difference_map(
         map_as_array=realspace_map_array,
         weight=maximizer.argument_optimum,
     )
-    final_realspace_map_as_ccp4 = numpy_array_to_map(
+    final_map = Map.from_numpy_map(
         final_realspace_map_as_array,
         spacegroup=difference_map.spacegroup,
         cell=difference_map.cell,
-    )
-
-    final_map = Map.from_ccp4_map(
-        ccp4_map=final_realspace_map_as_ccp4,
         high_resolution_limit=difference_map.resolution_limits[1],
     )
 

--- a/test/unit/test_rsmap.py
+++ b/test/unit/test_rsmap.py
@@ -277,7 +277,7 @@ def test_from_ccp4_map(ccp4_map: gemmi.Ccp4Map) -> None:
 def test_from_numpy(noise_free_map: Map) -> None:
     _, resolution = noise_free_map.resolution_limits
     array = np.array(noise_free_map.to_ccp4_map(map_sampling=3).grid)
-    new_map = Map.from_numpy_map(
+    new_map = Map.from_3d_numpy_map(
         array,
         spacegroup=noise_free_map.spacegroup,
         cell=noise_free_map.cell,
@@ -288,7 +288,7 @@ def test_from_numpy(noise_free_map: Map) -> None:
     assert_phases_allclose(new_map.phases, noise_free_map.phases)
 
     with pytest.raises(ValueError, match="`map_grid`"):
-        Map.from_numpy_map(
+        Map.from_3d_numpy_map(
             array[0, :, :],  # only has 2 dimensions
             spacegroup=noise_free_map.spacegroup,
             cell=noise_free_map.cell,


### PR DESCRIPTION
This PR resolves issue #26 and implements a new `.from_numpy_map` method on `Map`. The latter lets one instantiate a map object from a numpy array in one step instead of two.

Happy to have suggestions of how to name the function to make it clear that the numpy array should be a 3-d array of voxels in real space...