### PR TITLE
fix `rsmap.Map.copy()`

### DIFF
--- a/meteor/rsmap.py
+++ b/meteor/rsmap.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -106,8 +105,9 @@ class Map(rs.DataSet):
                 amplitude_column=self._amplitude_column,
                 phase_column=self._phase_column,
                 uncertainty_column=self._uncertainty_column,
-                **kwargs
+                **kwargs,
             )
+
         return constructor_fxn
 
     @property
@@ -195,28 +195,6 @@ class Map(rs.DataSet):
             msg = "columns are fixed for Map objects"
             raise MapMutabilityError(msg)
         return super().drop(labels=labels, axis=axis, columns=columns, inplace=inplace, **kwargs)
-
-    # def copy(self, *, deep: bool = True) -> Map:
-    #     # somewhat nasty method to ensure that non-standard column names are propogated OK
-    #     # the need for this could be removed, and in general the code simplified, if we simply
-    #     # were strict and required the columns to be named "F", "PHI", "SIGF"
-    #     #
-    #     # plus: in pandas 2.2.2, there are numerous calls with copy(deep=None) is this a bug?
-    #     # expected a bool. Here we always return deep copy, don't warn if deep=None - @tjlane
-    #     if deep is False:
-    #         warnings.warn(
-    #             "`Map` object has no shallow copy, returning deep copy instead",
-    #             UserWarning,
-    #             stacklevel=1,
-    #         )
-
-    #     _uncertainty_column = self._uncertainty_column if self.has_uncertainties else None
-    #     return type(self)(
-    #         self,
-    #         amplitude_column=self._amplitude_column,
-    #         phase_column=self._phase_column,
-    #         uncertainty_column=_uncertainty_column,
-    #     )
 
     def get_hkls(self) -> np.ndarray:
         # overwrite rs implt'n, return w/o modifying self -> same behavior, under testing - @tjlane

--- a/meteor/rsmap.py
+++ b/meteor/rsmap.py
@@ -100,7 +100,15 @@ class Map(rs.DataSet):
 
     @property
     def _constructor(self):
-        return Map
+        def constructor_fxn(*args, **kwargs):
+            return Map(
+                *args,
+                amplitude_column=self._amplitude_column,
+                phase_column=self._phase_column,
+                uncertainty_column=self._uncertainty_column,
+                **kwargs
+            )
+        return constructor_fxn
 
     @property
     def _constructor_sliced(self):
@@ -188,27 +196,27 @@ class Map(rs.DataSet):
             raise MapMutabilityError(msg)
         return super().drop(labels=labels, axis=axis, columns=columns, inplace=inplace, **kwargs)
 
-    def copy(self, *, deep: bool = True) -> Map:
-        # somewhat nasty method to ensure that non-standard column names are propogated OK
-        # the need for this could be removed, and in general the code simplified, if we simply
-        # were strict and required the columns to be named "F", "PHI", "SIGF"
-        #
-        # plus: in pandas 2.2.2, there are numerous calls with copy(deep=None) is this a bug?
-        # expected a bool. Here we always return deep copy, don't warn if deep=None - @tjlane
-        if deep is False:
-            warnings.warn(
-                "`Map` object has no shallow copy, returning deep copy instead",
-                UserWarning,
-                stacklevel=1,
-            )
+    # def copy(self, *, deep: bool = True) -> Map:
+    #     # somewhat nasty method to ensure that non-standard column names are propogated OK
+    #     # the need for this could be removed, and in general the code simplified, if we simply
+    #     # were strict and required the columns to be named "F", "PHI", "SIGF"
+    #     #
+    #     # plus: in pandas 2.2.2, there are numerous calls with copy(deep=None) is this a bug?
+    #     # expected a bool. Here we always return deep copy, don't warn if deep=None - @tjlane
+    #     if deep is False:
+    #         warnings.warn(
+    #             "`Map` object has no shallow copy, returning deep copy instead",
+    #             UserWarning,
+    #             stacklevel=1,
+    #         )
 
-        _uncertainty_column = self._uncertainty_column if self.has_uncertainties else None
-        return type(self)(
-            self,
-            amplitude_column=self._amplitude_column,
-            phase_column=self._phase_column,
-            uncertainty_column=_uncertainty_column,
-        )
+    #     _uncertainty_column = self._uncertainty_column if self.has_uncertainties else None
+    #     return type(self)(
+    #         self,
+    #         amplitude_column=self._amplitude_column,
+    #         phase_column=self._phase_column,
+    #         uncertainty_column=_uncertainty_column,
+    #     )
 
     def get_hkls(self) -> np.ndarray:
         # overwrite rs implt'n, return w/o modifying self -> same behavior, under testing - @tjlane

--- a/meteor/utils.py
+++ b/meteor/utils.py
@@ -64,7 +64,7 @@ def canonicalize_amplitudes(
     inplace: bool = False,
 ) -> rs.DataSet | None:
     if not inplace:
-        dataset = dataset.copy(deep=True)
+        dataset = dataset.copy()
 
     negative_amplitude_indices = dataset[amplitude_label] < 0.0
     dataset[amplitude_label] = np.abs(dataset[amplitude_label])

--- a/test/unit/test_rsmap.py
+++ b/test/unit/test_rsmap.py
@@ -49,7 +49,7 @@ def test_amplitude_and_phase_required(noise_free_map: Map) -> None:
 def test_loc_indexing(random_difference_map: Map) -> None:
     ds = rs.DataSet(random_difference_map).rename(columns={"F": "amps", "PHI": "phases"})
     non_std_map = Map(ds, amplitude_column="amps", phase_column="phases")
-    indx = [(0,0,1), (1,2,3)]
+    indx = [(0, 0, 1), (1, 2, 3)]
     assert non_std_map.loc[indx] is not None
 
 

--- a/test/unit/test_rsmap.py
+++ b/test/unit/test_rsmap.py
@@ -46,6 +46,13 @@ def test_amplitude_and_phase_required(noise_free_map: Map) -> None:
         Map(ds)
 
 
+def test_loc_indexing(random_difference_map: Map) -> None:
+    ds = rs.DataSet(random_difference_map).rename(columns={"F": "amps", "PHI": "phases"})
+    non_std_map = Map(ds, amplitude_column="amps", phase_column="phases")
+    indx = [(0,0,1), (1,2,3)]
+    assert non_std_map.loc[indx] is not None
+
+
 def test_reset_index(noise_free_map: Map) -> None:
     modmap = noise_free_map.reset_index()
     assert len(modmap.columns) == len(noise_free_map.columns) + 3

--- a/test/unit/test_rsmap.py
+++ b/test/unit/test_rsmap.py
@@ -54,7 +54,27 @@ def test_reset_index(noise_free_map: Map) -> None:
 def test_copy(noise_free_map: Map) -> None:
     copy_map = noise_free_map.copy()
     assert isinstance(copy_map, Map)
+    assert copy_map is not noise_free_map
     pd.testing.assert_frame_equal(copy_map, noise_free_map)
+
+    # ensure deep copy
+    assert copy_map.values is not noise_free_map.values  # noqa: PD011, want to ensure deep copy
+    assert np.all(noise_free_map["F"] == copy_map["F"])
+    copy_map["F"] += 1.0
+    assert np.all(noise_free_map["F"] != copy_map["F"])
+
+
+def test_copy_non_standard_names(noise_free_map: Map) -> None:
+    ds = rs.DataSet(noise_free_map).rename(columns={"F": "amps", "PHI": "phases"})
+    non_std_map = Map(ds, amplitude_column="amps", phase_column="phases")
+    copy_map = non_std_map.copy()
+
+    assert isinstance(copy_map, Map)
+    assert copy_map is not non_std_map
+    assert copy_map.values is not non_std_map.values  # noqa: PD011, want to ensure deep copy
+    assert "amps" in copy_map.columns
+    assert "phases" in copy_map.columns
+    pd.testing.assert_frame_equal(copy_map, non_std_map)
 
 
 def test_filter_common_indices_with_maps(noise_free_map: Map) -> None:


### PR DESCRIPTION
@alisiafadini discovered a bug: when calling `Map.copy()` on a `Map` with non-standard column names (ie, anything but "F", "PHI", and "SIGF") then the code would crash. The variables that stored those column names were not getting propagated to the child of the copy correctly.

This PR fixes that 🐞 .

Note that I had to do a little python magic, specifically using `type(self)`, that makes me uncomfortable. This may have consequences. Also, I cannot re-implement `pandas` shallow copy, but I don't think we need it. So overall, not the best situation.

This is documented clearly, though, and should not stop us. Further improvements are possible in the future.