### PR TITLE
TV optimization: return negentropies at evaluated points

### DIFF
--- a/meteor/iterative.py
+++ b/meteor/iterative.py
@@ -122,7 +122,7 @@ def _complex_derivative_from_iterative_tv(
         metadata.append(
             {
                 "iteration": num_iterations,
-                "tv_weight": tv_metadata.optimal_lambda,
+                "tv_weight": tv_metadata.optimal_weight,
                 "negentropy_after_tv": tv_metadata.optimal_negentropy,
                 "average_phase_change": phase_change,
             },
@@ -160,7 +160,7 @@ def iterative_tv_phase_retrieval(
             Fh' = (D_F' + F) * [|Fh| / |D_F' + F|]  Fourier space projection onto experimental set
             D_F = Fh' - F
 
-    Where the TV lambda parameter is determined using golden section optimization. The algorithm
+    Where the TV weight parameter is determined using golden section optimization. The algorithm
     iterates until the changes in the derivative phase drop below a specified threshold.
 
     Parameters
@@ -202,7 +202,7 @@ def iterative_tv_phase_retrieval(
 
         denoised_map, tv_metadata = tv_denoise_difference_map(
             diffmap,
-            lambda_values_to_scan=tv_weights_to_scan,
+            weights_to_scan=tv_weights_to_scan,
             full_output=True,
         )
 

--- a/meteor/settings.py
+++ b/meteor/settings.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-TV_LAMBDA_RANGE: tuple[float, float] = (1e-3, 1.0)
+TV_WEIGHT_RANGE: tuple[float, float] = (1e-3, 1.0)
 TV_STOP_TOLERANCE: float = 0.00000005
 TV_MAX_NUM_ITER: int = 50
 MAP_SAMPLING: int = 3

--- a/test/unit/test_iterative.py
+++ b/test/unit/test_iterative.py
@@ -29,9 +29,10 @@ def simple_tv_function(fourier_array: np.ndarray) -> tuple[np.ndarray, TvDenoise
     real_space = np.fft.ifftn(fourier_array).real
     denoised = denoise_tv_chambolle(real_space, weight=weight)  # type: ignore[no-untyped-call]
     result = TvDenoiseResult(
-        optimal_lambda=weight,
+        optimal_weight=weight,
         optimal_negentropy=0.0,
-        lambdas_scanned={weight},
+        weights_scanned=[weight],
+        negentropy_at_weights=[0.0],
         map_sampling_used_for_tv=0,
     )
     return np.fft.fftn(denoised), result

--- a/test/unit/test_validate.py
+++ b/test/unit/test_validate.py
@@ -40,7 +40,8 @@ def test_negentropy_maximizer_explicit() -> None:
     maximizer.optimize_over_explicit_values(arguments_to_scan=test_values)
     assert_almost_equal(maximizer.argument_optimum, 1.0)
     assert_almost_equal(maximizer.objective_maximum, 0.0)
-    assert set(test_values) == maximizer.values_evaluated
+    assert list(test_values) == maximizer.values_evaluated
+    assert len(maximizer.values_evaluated) == len(maximizer.objective_at_values)
 
 
 def test_negentropy_maximizer_golden() -> None:
@@ -49,3 +50,4 @@ def test_negentropy_maximizer_golden() -> None:
     assert_almost_equal(maximizer.argument_optimum, 1.0, decimal=2)
     assert_almost_equal(maximizer.objective_maximum, 0.0, decimal=2)
     assert len(maximizer.values_evaluated) > 0
+    assert len(maximizer.values_evaluated) == len(maximizer.objective_at_values)


### PR DESCRIPTION
This PR also changes all instances of "lambda" in a TV context to "weight"; previously we had a mix of both terms.