### PR TITLE
use golden optimization for TV weight

### DIFF
--- a/meteor/diffmaps.py
+++ b/meteor/diffmaps.py
@@ -174,7 +174,7 @@ def max_negentropy_kweighted_difference_map(
 
     maximizer = ScalarMaximizer(objective=negentropy_objective)
     maximizer.optimize_over_explicit_values(arguments_to_scan=k_parameter_values_to_scan)
-    opt_k_parameter = maximizer.argument_optimum
+    opt_k_parameter = float(maximizer.argument_optimum)
 
     kweighted_dataset = compute_kweighted_difference_map(
         derivative,

--- a/meteor/iterative.py
+++ b/meteor/iterative.py
@@ -122,7 +122,7 @@ def _complex_derivative_from_iterative_tv(
         metadata.append(
             {
                 "iteration": num_iterations,
-                "tv_weight": tv_metadata.optimal_weight,
+                "tv_weight": tv_metadata.optimal_tv_weight,
                 "negentropy_after_tv": tv_metadata.optimal_negentropy,
                 "average_phase_change": phase_change,
             },

--- a/meteor/scripts/compute_difference_map.py
+++ b/meteor/scripts/compute_difference_map.py
@@ -157,7 +157,7 @@ def denoise_diffmap_according_to_mode(
 
         log.info(
             "Optimal TV weight found",
-            weight=metadata.optimal_weight,
+            weight=metadata.optimal_tv_weight,
             initial_negentropy=f"{metadata.initial_negentropy:.2e}",
             final_negetropy=f"{metadata.optimal_negentropy:.2e}",
         )
@@ -187,9 +187,9 @@ def denoise_diffmap_according_to_mode(
         metadata = TvDenoiseResult(
             initial_negentropy=map_negetropy,
             optimal_negentropy=map_negetropy,
-            optimal_weight=0.0,
+            optimal_tv_weight=0.0,
             map_sampling_used_for_tv=MAP_SAMPLING,
-            weights_scanned=[0.0],
+            tv_weights_scanned=[0.0],
             negentropy_at_weights=[map_negetropy],
         )
 

--- a/meteor/scripts/compute_difference_map.py
+++ b/meteor/scripts/compute_difference_map.py
@@ -20,10 +20,6 @@ from .common import DiffmapArgParser, DiffMapSet, InvalidWeightModeError, Weight
 log = structlog.get_logger()
 
 
-# TO OPTMIZE
-TV_WEIGHTS_TO_SCAN = np.linspace(0.0, 0.1, 101)
-
-
 class TvDiffmapArgParser(DiffmapArgParser):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -153,16 +149,11 @@ def denoise_diffmap_according_to_mode(
     """
     if tv_denoise_mode == WeightMode.optimize:
         log.info(
-            "Searching for max-negentropy TV denoising weight",
-            min=np.min(TV_WEIGHTS_TO_SCAN),
-            max=np.max(TV_WEIGHTS_TO_SCAN),
-            points_to_test=len(TV_WEIGHTS_TO_SCAN),
+            "Searching for max-negentropy TV denoising weight", method="golden ration optimization"
         )
         log.info("This may take some time...")
 
-        final_map, metadata = tv_denoise_difference_map(
-            diffmap, full_output=True, weights_to_scan=TV_WEIGHTS_TO_SCAN
-        )
+        final_map, metadata = tv_denoise_difference_map(diffmap, full_output=True)
 
         log.info(
             "Optimal TV weight found",

--- a/meteor/settings.py
+++ b/meteor/settings.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-TV_WEIGHT_RANGE: tuple[float, float] = (0.0, 0.05)  # for golden optimization
+BRACKET_FOR_GOLDEN_OPTIMIZATION: tuple[float, float] = (0.0, 0.05)
 TV_STOP_TOLERANCE: float = 0.00000005
 TV_MAX_NUM_ITER: int = 50
 MAP_SAMPLING: int = 3

--- a/meteor/settings.py
+++ b/meteor/settings.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-TV_WEIGHT_RANGE: tuple[float, float] = (0.0, 1.0)
+TV_WEIGHT_RANGE: tuple[float, float] = (0.0, 0.05)  # for golden optimization
 TV_STOP_TOLERANCE: float = 0.00000005
 TV_MAX_NUM_ITER: int = 50
 MAP_SAMPLING: int = 3
 
 KWEIGHT_PARAMETER_DEFAULT: float = 0.05
-TV_WEIGHT_DEFAULT: float = 0.01  # TO OPTIMIZE
+TV_WEIGHT_DEFAULT: float = 0.01
 
 COMPUTED_MAP_RESOLUTION_LIMIT: float = 1.0
 GEMMI_HIGH_RESOLUTION_BUFFER: float = 1e-6

--- a/test/functional/test_compute_difference_map.py
+++ b/test/functional/test_compute_difference_map.py
@@ -85,8 +85,9 @@ def test_script_produces_consistent_results(
                 err_msg="tv weight optimium different from expected",
             )
         else:
+            optimal_tv_with_weighting = 0.00867
             np.testing.assert_allclose(
-                tv_weight,
+                optimal_tv_with_weighting,
                 result_metadata.optimal_weight,
                 rtol=0.1,
                 err_msg="tv weight optimium different from expected",

--- a/test/functional/test_compute_difference_map.py
+++ b/test/functional/test_compute_difference_map.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from unittest import mock
 
 import numpy as np
 import pytest
@@ -11,10 +10,7 @@ from meteor.scripts.common import WeightMode
 from meteor.tv import TvDenoiseResult
 from meteor.utils import filter_common_indices
 
-TV_WEIGHTS_TO_SCAN = np.array([0.005, 0.01, 0.025, 0.5])
 
-
-@mock.patch("meteor.scripts.compute_difference_map.TV_WEIGHTS_TO_SCAN", TV_WEIGHTS_TO_SCAN)
 @pytest.mark.parametrize("kweight_mode", list(WeightMode))
 @pytest.mark.parametrize("tv_weight_mode", list(WeightMode))
 def test_script_produces_consistent_results(

--- a/test/functional/test_compute_difference_map.py
+++ b/test/functional/test_compute_difference_map.py
@@ -80,7 +80,7 @@ def test_script_produces_consistent_results(
             optimal_tv_no_kweighting = 0.025
             np.testing.assert_allclose(
                 optimal_tv_no_kweighting,
-                result_metadata.optimal_weight,
+                result_metadata.optimal_tv_weight,
                 rtol=0.1,
                 err_msg="tv weight optimium different from expected",
             )
@@ -88,7 +88,7 @@ def test_script_produces_consistent_results(
             optimal_tv_with_weighting = 0.00867
             np.testing.assert_allclose(
                 optimal_tv_with_weighting,
-                result_metadata.optimal_weight,
+                result_metadata.optimal_tv_weight,
                 rtol=0.1,
                 err_msg="tv weight optimium different from expected",
             )

--- a/test/unit/scripts/test_compute_difference_map.py
+++ b/test/unit/scripts/test_compute_difference_map.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Any
 from unittest import mock
 
-import numpy as np
 import pytest
 
 from meteor.rsmap import Map
@@ -17,10 +16,6 @@ from meteor.scripts.compute_difference_map import (
     kweight_diffmap_according_to_mode,
 )
 from meteor.tv import TvDenoiseResult
-
-# ensure tests complete quickly by monkey-patching a limited number of weights
-compute_difference_map.TV_WEIGHTS_TO_SCAN = np.linspace(0.0, 0.1, 6)
-
 
 TV_WEIGHT = 0.1
 
@@ -80,7 +75,8 @@ def test_denoise_diffmap_according_to_mode(mode: WeightMode, random_difference_m
     assert isinstance(metadata, TvDenoiseResult)
 
     if mode == WeightMode.optimize:
-        assert metadata.optimal_weight in [0.04, 0.06]  # random test; alternates
+        # random test; changes
+        assert 0.04 < metadata.optimal_weight < 0.06
 
     elif mode == WeightMode.fixed:
         assert metadata.optimal_weight == TV_WEIGHT

--- a/test/unit/scripts/test_compute_difference_map.py
+++ b/test/unit/scripts/test_compute_difference_map.py
@@ -76,17 +76,17 @@ def test_denoise_diffmap_according_to_mode(mode: WeightMode, random_difference_m
 
     if mode == WeightMode.optimize:
         # random test; changes
-        assert 0.04 < metadata.optimal_weight < 0.06
+        assert 0.04 < metadata.optimal_tv_weight < 0.06
 
     elif mode == WeightMode.fixed:
-        assert metadata.optimal_weight == TV_WEIGHT
+        assert metadata.optimal_tv_weight == TV_WEIGHT
         with pytest.raises(TypeError):
             _, _ = denoise_diffmap_according_to_mode(
                 diffmap=random_difference_map, tv_denoise_mode=mode, tv_weight=None
             )
 
     elif mode == WeightMode.none:
-        assert metadata.optimal_weight == 0.0
+        assert metadata.optimal_tv_weight == 0.0
 
 
 def test_main(diffmap_set: DiffMapSet, tmp_path: Path, fixed_kparameter: float) -> None:

--- a/test/unit/test_iterative.py
+++ b/test/unit/test_iterative.py
@@ -30,9 +30,9 @@ def simple_tv_function(fourier_array: np.ndarray) -> tuple[np.ndarray, TvDenoise
     denoised = denoise_tv_chambolle(real_space, weight=weight)  # type: ignore[no-untyped-call]
     result = TvDenoiseResult(
         initial_negentropy=0.0,
-        optimal_weight=weight,
+        optimal_tv_weight=weight,
         optimal_negentropy=1.0,
-        weights_scanned=[weight],
+        tv_weights_scanned=[weight],
         negentropy_at_weights=[1.0],
         map_sampling_used_for_tv=0,
     )

--- a/test/unit/test_tv.py
+++ b/test/unit/test_tv.py
@@ -30,10 +30,10 @@ def rms_between_coefficients(map1: Map, map2: Map) -> float:
 def tv_denoise_result_source_data() -> dict:
     return {
         "initial_negentropy": 0.0,
-        "optimal_weight": 1.0,
+        "optimal_tv_weight": 1.0,
         "optimal_negentropy": 5.0,
         "map_sampling_used_for_tv": 5,
-        "weights_scanned": [0.0, 1.0],
+        "tv_weights_scanned": [0.0, 1.0],
         "negentropy_at_weights": [0.0, 5.0],
         "k_parameter_used": 0.0,
     }
@@ -131,4 +131,4 @@ def test_tv_denoise_map(
     )
 
     assert rms_to_noise_free(denoised_map) < rms_to_noise_free(noisy_map), "error didnt drop"
-    np.testing.assert_allclose(result.optimal_weight, best_weight, rtol=0.5, err_msg="opt weight")
+    np.testing.assert_allclose(result.optimal_tv_weight, best_weight, rtol=0.5, err_msg="opt weight")


### PR DESCRIPTION
@alisiafadini check it out. Using your rsEGFP2 test case,

```
meteor.diffmap 8a6g_all.mtz -da F_on -du SIGF_on 8a6g_all.mtz -na F_off -nu F_off
```

Fixed weight scan with 101 points:
* best TV weight: 0.007
* final negentropy: 0.070
* time: 133.94s

Using this branch (golden with more limited scan window):
* best TV weight: 0.0071
* final negentropy: 0.071
* time: 52.33s